### PR TITLE
Fix Pagination

### DIFF
--- a/lib/esp_sdk/end_points/base.rb
+++ b/lib/esp_sdk/end_points/base.rb
@@ -94,8 +94,8 @@ module EspSdk
         end
       end
 
-      def current_page=(value)
-        @current_page = ActiveSupport::HashWithIndifferentAccess.new(value)
+      def current_page=(values)
+        @current_page = values.map(&:with_indifferent_access)
       end
     end
   end


### PR DESCRIPTION
I discovered that the `next_page` and `prev_page` methods were not working, but tests were passing. 

It turned out to be due to the `HashWithIndifferentAccess` being called directly on the value, which from the list page is an `Array` not a `Hash`. Tests were passing before because they were setting up the values as a hash instead of an array for the list action.

The `current_page=` method only looks to be used by the list action, so it should always be an array. I've updated the current page method to map the values and updated the tests to send an array instead.