### PR TITLE
Override list to return hash

### DIFF
--- a/lib/esp_sdk/end_points/dashboard.rb
+++ b/lib/esp_sdk/end_points/dashboard.rb
@@ -1,6 +1,11 @@
 module EspSdk
   module EndPoints
     class Dashboard < Base
+      def list
+        response = connect(base_url, :get)
+        @current_page = JSON.load(response.body).with_indifferent_access
+      end
+
       def timewarp(params = {})
         validate_timewarp_params(params.keys)
         submit(timewarp_url, :post, params)


### PR DESCRIPTION
The `list` action in the Base class assumes the response will be an array. The dashboard endpoint is an oddball and returns a hash that includes an array. Overriding list here to handle it manually.