### PR TITLE
Unlock ActiveSupport Version

### DIFF
--- a/esp_sdk.gemspec
+++ b/esp_sdk.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha', '~> 1.1.0'
   spec.add_development_dependency 'fakeweb', '~> 1.3'
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.1.6'
+  spec.add_runtime_dependency 'activesupport', '>= 3.0.0'
   spec.add_runtime_dependency 'rest_client', '~> 1.7.3'
   spec.add_runtime_dependency 'pry', '~> 0.10.1'
   spec.add_runtime_dependency 'awesome_print', '~> 1.2.0'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ CodeClimate::TestReporter.start
 require 'esp_sdk'
 require 'minitest/autorun'
 require 'minitest/reporters'
+require 'mocha/mini_test'
 require 'shoulda'
 require 'mocha'
 require 'fakeweb'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'mocha/mini_test'
 require 'shoulda'
-require 'mocha'
 require 'fakeweb'
 require 'awesome_print'
 


### PR DESCRIPTION
We only depend on ActiveSupport for HashWithIndifferentAccess. This has been available since 3.0.0, and is still included in future versions. Unlocking this so users can user whichever version they prefer.