### PR TITLE
Adding option to pass the domain to use for the API

### DIFF
--- a/lib/esp_sdk/configure.rb
+++ b/lib/esp_sdk/configure.rb
@@ -1,32 +1,36 @@
 module EspSdk
   class Configure
-    attr_accessor :token, :email, :version, :token_expires_at
+    attr_accessor :token, :email, :version, :token_expires_at, :end_point, :domain
 
     def initialize(options)
-      @email   = options[:email]
-      @version = options[:version] || 'v1'
-      token_setup(options)
+      self.email = options[:email]
+      self.version = options[:version] || 'v1'
+      self.domain = options[:domain]
+      self.token = options[:password] || options[:token]
+      self.end_point = options[:password].present? ? 'new' : 'valid'
+      token_setup
     end
 
-    def uri
-      return @uri if @uri.present?
+    def url(endpoint)
+      "#{domain}/api/#{version}/#{endpoint}"
+    end
 
+    def domain
+      return @domain if @domain.present?
       if EspSdk.production?
-        @uri = 'https://api.evident.io/api'
+        self.domain = 'https://api.evident.io'
       elsif EspSdk.release?
-        @uri = 'https://api-rel.evident.io/api'
+        self.domain = 'https://api-rel.evident.io'
       else
-        @uri = 'http://0.0.0.0:3000/api'
+        self.domain = 'http://0.0.0.0:3000'
       end
     end
 
     private
 
-    def token_setup(options)
-      self.token = options[:password] || options[:token]
-      end_point  = options[:password].present? ? 'new' : 'valid'
+    def token_setup
       client     = Client.new(self)
-      response   = client.connect("#{uri}/#{version}/token/#{end_point}")
+      response   = client.connect(url("token/#{end_point}"))
       user       = JSON.load(response.body)
       self.token = user['authentication_token']
       self.token_expires_at = user['token_expires_at'].to_s.to_datetime.utc ||

--- a/lib/esp_sdk/end_points/base.rb
+++ b/lib/esp_sdk/end_points/base.rb
@@ -70,7 +70,7 @@ module EspSdk
       end
 
       def base_url
-        "#{config.uri}/#{config.version}/#{self.class.to_s.demodulize.underscore}"
+        config.url(self.class.to_s.demodulize.underscore)
       end
 
       def submit(url, type, options = {})

--- a/test/esp_sdk/api_test.rb
+++ b/test/esp_sdk/api_test.rb
@@ -5,17 +5,17 @@ class ApiTest < ActiveSupport::TestCase
     context '#initalize' do
       should 'raise a MissingAttribute error for a missing email' do
         e = assert_raises EspSdk::MissingAttribute do
-          EspSdk::Api.new({ })
+          EspSdk::Api.new()
         end
-        assert_equal 'Missing required email', e.message
 
+        assert_equal 'Missing required email', e.message
       end
       should 'raise a MissingAttribute error for a missing token and password' do
         e = assert_raises EspSdk::MissingAttribute do
           EspSdk::Api.new(email: 'test@evident.io')
         end
-        assert_equal 'Missing required password', e.message
 
+        assert_equal 'Missing required password', e.message
       end
 
       should 'define our endpoint methods and add them to the end_points array' do

--- a/test/esp_sdk/configure_test.rb
+++ b/test/esp_sdk/configure_test.rb
@@ -5,44 +5,60 @@ class ConfigureTest < ActiveSupport::TestCase
     setup do
       # Stub the setup token method
       EspSdk::Configure.any_instance.expects(:token_setup).returns(nil).at_least_once
-      @config = EspSdk::Configure.new({email: 'test@test.com', token: 'token'})
+      @config = EspSdk::Configure.new(email: 'test@test.com', token: 'token')
     end
 
     context '#initialize' do
       should 'set a default version of v1' do
         assert_equal 'v1', @config.version
       end
+
+      should 'should setup the token and token and expires at' do
+        EspSdk::Configure.any_instance.unstub(:token_setup)
+        FakeWeb.register_uri(:get, %r{api/v1/token/new},
+                             body: { authentication_token: 'token',
+                                     token_expires_at: 1.hour.from_now }.to_json)
+
+        config = EspSdk::Configure.new(email: 'test@test.com', password: 'password1234')
+
+        assert_not_nil config.token
+        assert_not_nil config.token_expires_at
+      end
     end
 
-    context '#uri' do
+    context 'url' do
+      should 'return domain with api/version/end_point' do
+        @config = EspSdk::Configure.new(email: 'test@test.com', token: 'token', domain: 'https://test.domain.com', version: 'v4')
+
+        assert_equal 'https://test.domain.com/api/v4/users', @config.url('users')
+      end
+    end
+
+    context '#domain' do
+      should 'return custom URI when the URI is passed in' do
+        @config = EspSdk::Configure.new(email: 'test@test.com', token: 'token', domain: 'https://test.domain.com')
+
+        assert_equal 'https://test.domain.com', @config.domain
+      end
+
       should 'return the production URI when the environment is production' do
         EspSdk.expects(:production?).returns(true)
-        assert_equal 'https://api.evident.io/api', @config.uri
+
+        assert_equal 'https://api.evident.io', @config.domain
       end
 
       should 'return the release URI when the environment is release' do
         EspSdk.expects(:production?).returns(false)
         EspSdk.expects(:release?).returns(true)
-        assert_equal 'https://api-rel.evident.io/api', @config.uri
+
+        assert_equal 'https://api-rel.evident.io', @config.domain
       end
 
       should 'return the development URI when the environment is not release or production' do
         EspSdk.expects(:production?).returns(false)
         EspSdk.expects(:release?).returns(false)
-        assert_equal 'http://0.0.0.0:3000/api', @config.uri
-      end
-    end
 
-    context '#token_setup' do
-      setup { EspSdk::Configure.any_instance.unstub(:token_setup) }
-
-      should 'should set the token and token and expires at' do
-        FakeWeb.register_uri(:get, /api\/v1\/token\/new/,
-                             :body => { authentication_token: 'token',
-                                        token_expires_at: 1.hour.from_now }.to_json)
-        @config.send(:token_setup, { password: 'password1234' })
-        assert_not_nil @config.token
-        assert_not_nil @config.token_expires_at
+        assert_equal 'http://0.0.0.0:3000', @config.domain
       end
     end
   end


### PR DESCRIPTION
You can now pass the domain to use for the API. This is so we can get around hardcoding of the domain in situations where the hardcoded domain may not be the one we want to use.

```ruby
EspSdk::Api.new(email: 'test@google.com', password: 'test', domain: 'http://newdomain.com')
```