### PR TITLE
Change to better handle error messages on nested objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Some error messages changed a little bit on the API.  Specifically, on region suppression, signature suppress, and custom signature suppression objects.  Now when a validation trips on the related suppression object, then error message reflects that.  "Reason can't be blank" changed to "Suppression region can't be blank".  The message is built from the attribute which is in error, which changed from "Reason" to "Suppression.reason".  Had to gsub the "." to a space to make it message friendly.
+
 ## 2.2.0 - 2016-03-2
 ### Added
 - Added the ESP::ScanInterval object to use the new scan interval endpoint on the API

--- a/lib/esp/extensions/active_resource/formats/json_api_format.rb
+++ b/lib/esp/extensions/active_resource/formats/json_api_format.rb
@@ -37,7 +37,7 @@ module ActiveResource # :nodoc: all
       end
 
       def decode(json)
-        # ap ActiveSupport::JSON.decode(json), index: false, indent: -2
+        # pp ActiveSupport::JSON.decode(json), index: false, indent: -2
         Formats.remove_root(parse_json_api(ActiveSupport::JSON.decode(json)))
       end
 

--- a/lib/esp/extensions/active_resource/validations.rb
+++ b/lib/esp/extensions/active_resource/validations.rb
@@ -35,7 +35,7 @@ module ActiveResource # :nodoc: all
         raw_errors.each do |error|
           next unless error['meta']
           error['meta'].map do |attr, message|
-            friendly_attr = attr.gsub('.', ' ')
+            friendly_attr = attr.tr('.', ' ')
             errors[friendly_attr] ||= []
             errors[friendly_attr] << message
           end

--- a/lib/esp/extensions/active_resource/validations.rb
+++ b/lib/esp/extensions/active_resource/validations.rb
@@ -35,8 +35,9 @@ module ActiveResource # :nodoc: all
         raw_errors.each do |error|
           next unless error['meta']
           error['meta'].map do |attr, message|
-            errors[attr] ||= []
-            errors[attr] << message
+            friendly_attr = attr.gsub('.', ' ')
+            errors[friendly_attr] ||= []
+            errors[friendly_attr] << message
           end
         end
       end

--- a/lib/esp/resources/report.rb
+++ b/lib/esp/resources/report.rb
@@ -53,7 +53,7 @@ module ESP
     # ==== Example
     #
     #   report = ESP::Report.find(345)
-    #   alerts = report.alerts(status: 'fail', signature_severity: 'High')
+    #   alerts = report.alerts(status_eq: 'fail', signature_risk_level_in: ['High'])
     def alerts(arguments = {})
       ESP::Alert.where(arguments.merge(report_id: id))
     end

--- a/test/esp/integration/suppression_region_integration_test.rb
+++ b/test/esp/integration/suppression_region_integration_test.rb
@@ -13,7 +13,7 @@ module ESP::Integration
 
               suppression = ESP::Suppression::Region.create(signature_ids: [signature_id], custom_signature_ids: [], regions: [region.code], external_account_ids: [external_account_id])
 
-              assert_equal "Reason can't be blank", suppression.errors.full_messages.first
+              assert_equal "Suppression reason can't be blank", suppression.errors.full_messages.first
             end
 
             should 'return suppression' do
@@ -32,7 +32,7 @@ module ESP::Integration
 
                 suppression = ESP::Suppression::Region.create(alert_id: alert_id)
 
-                assert_equal "Reason can't be blank", suppression.errors.full_messages.first
+                assert_equal "Suppression reason can't be blank", suppression.errors.full_messages.first
               end
 
               should 'return suppression' do

--- a/test/esp/integration/suppression_signature_integration_test.rb
+++ b/test/esp/integration/suppression_signature_integration_test.rb
@@ -13,7 +13,7 @@ module ESP::Integration
 
               suppression = ESP::Suppression::Signature.create(signature_ids: [signature_id], custom_signature_ids: [], regions: [region.code], external_account_ids: [external_account_id])
 
-              assert_equal "Reason can't be blank", suppression.errors.full_messages.first
+              assert_equal "Suppression reason can't be blank", suppression.errors.full_messages.first
             end
 
             should 'return suppression' do
@@ -32,7 +32,7 @@ module ESP::Integration
 
                 suppression = ESP::Suppression::Signature.create(alert_id: alert_id)
 
-                assert_equal "Reason can't be blank", suppression.errors.full_messages.first
+                assert_equal "Suppression reason can't be blank", suppression.errors.full_messages.first
               end
 
               should 'return suppression' do

--- a/test/esp/integration/suppression_unique_identifier_integration_test.rb
+++ b/test/esp/integration/suppression_unique_identifier_integration_test.rb
@@ -11,7 +11,7 @@ module ESP::Integration
 
               suppression = ESP::Suppression::UniqueIdentifier.create(alert_id: alert_id)
 
-              assert_equal "Reason can't be blank", suppression.errors.full_messages.first
+              assert_equal "Suppression reason can't be blank", suppression.errors.full_messages.first
             end
 
             should 'return suppression' do


### PR DESCRIPTION
Some error messages changed a little bit on the API.  Specifically, on region suppression, signature suppress, and custom signature suppression objects.  Now when a validation trips on the related suppression object, then error message reflects that.  "Reason can't be blank" changed to "Suppression region can't be blank".  The message is built from the attribute which is in error, which changed from "Reason" to "Suppression.reason".  Had to gsub the "." to a space to make it message friendly.