### PR TITLE
Add Support for Custom Signature Definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Add custom signature definitions and results. Code for a custom signature is now created/updated under a definition. Running a definition for an on demand test creates a result record which will have errors and alerts when completed.
 
 ## 2.4.0 - 2016-06-30
 ### Added

--- a/lib/esp.rb
+++ b/lib/esp.rb
@@ -102,11 +102,6 @@ module ESP
   autoload :Tag, File.expand_path(File.dirname(__FILE__) + '/esp/resources/tag')
   autoload :Region, File.expand_path(File.dirname(__FILE__) + '/esp/resources/region')
   autoload :Suppression, File.expand_path(File.dirname(__FILE__) + '/esp/resources/suppression')
-  class Suppression
-    autoload :UniqueIdentifier, File.expand_path(File.dirname(__FILE__) + '/esp/resources/suppression/unique_identifier')
-    autoload :Signature, File.expand_path(File.dirname(__FILE__) + '/esp/resources/suppression/signature')
-    autoload :Region, File.expand_path(File.dirname(__FILE__) + '/esp/resources/suppression/region')
-  end
   autoload :Stat, File.expand_path(File.dirname(__FILE__) + '/esp/resources/stat')
   autoload :StatCustomSignature, File.expand_path(File.dirname(__FILE__) + '/esp/resources/stat_custom_signature')
   autoload :StatSignature, File.expand_path(File.dirname(__FILE__) + '/esp/resources/stat_signature')
@@ -114,9 +109,4 @@ module ESP
   autoload :StatService, File.expand_path(File.dirname(__FILE__) + '/esp/resources/stat_service')
   autoload :ExternalAccountCreator, File.expand_path(File.dirname(__FILE__) + '/../lib/esp/external_account_creator')
   autoload :AWSClients, File.expand_path(File.dirname(__FILE__) + '/../lib/esp/aws_clients')
-  class Report
-    module Export
-      autoload :Integration, File.expand_path(File.dirname(__FILE__) + '/esp/resources/reports/export/integration')
-    end
-  end
 end

--- a/lib/esp/resources/custom_signature.rb
+++ b/lib/esp/resources/custom_signature.rb
@@ -1,108 +1,18 @@
 module ESP
   class CustomSignature < ESP::Resource
+    autoload :Definition, File.expand_path(File.dirname(__FILE__) + '/custom_signature/definition')
+    autoload :Result, File.expand_path(File.dirname(__FILE__) + '/custom_signature/result')
+
     ##
     # The organization this custom signature belongs to.
     belongs_to :organization, class_name: 'ESP::Organization'
+    has_many :definitions, class_name: 'ESP::CustomSignature::Definition'
 
     ##
     # The collection of teams that belong to the custom_signature.
     def teams
       return attributes['teams'] if attributes['teams'].present?
       Team.where(custom_signatures_id_eq: id)
-    end
-
-    # Run a custom signature that has not been saved.  Useful for debugging a custom signature.
-    # Returns a collection of alerts.
-    # Throws an error if not successful.
-    #
-    # ==== Parameters
-    #
-    # +arguments+ | Required | A hash of run arguments
-    #
-    # ===== Valid Arguments
-    #
-    # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-run-new] for valid arguments
-    #
-    # ==== Example
-    #   signature = "# Demo Ruby Signature\r\nconfigure do |c|\r\n  # Set regions to run in. Remove this line to run in all regions.\r\n  c.valid_regions     = [:us_east_1]\r\n  # Override region to display as global. Useful when checking resources\r\n  # like IAM that do not have a specific region.\r\n  c.display_as        = :global\r\n  # deep_inspection works with set_data to automically collect\r\n  # data fields for each alert. Not required.\r\n  c.deep_inspection   = [:users]\r\nend\r\n\r\n# Required perform method\r\ndef perform(aws)\r\n  list_users = aws.iam.list_users\r\n  count = list_users[:users].count\r\n\r\n  # Set data for deep_inspection to use\r\n  set_data(list_users)\r\n\r\n  if count == 0\r\n    fail(user_count: count, condition: 'count == 0')\r\n  else\r\n    pass(user_count: count, condition: 'count >= 1')\r\n  end\r\nend\r\n"
-    #   alerts = ESP::CustomSignature.run!(external_account_id: 3, regions: ['us_east_1'], language: 'ruby', signature: signature)
-    def self.run!(arguments = {})
-      result = run(arguments)
-      return result if result.is_a?(ActiveResource::Collection)
-      result.message = result.errors.full_messages.join(' ')
-      fail(ActiveResource::ResourceInvalid.new(result)) # rubocop:disable Style/RaiseArgs
-    end
-
-    # Run a custom signature that has not been saved.  Useful for debugging a custom signature.
-    # Returns a collection of alerts.
-    # If not successful, returns a CustomSignature object with the errors object populated.
-    #
-    # ==== Parameters
-    #
-    # +arguments+ | Required | A hash of run arguments
-    #
-    # ===== Valid Arguments
-    #
-    # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-run-new] for valid arguments
-    #
-    # ==== Example
-    #   signature = "# Demo Ruby Signature\r\nconfigure do |c|\r\n  # Set regions to run in. Remove this line to run in all regions.\r\n  c.valid_regions     = [:us_east_1]\r\n  # Override region to display as global. Useful when checking resources\r\n  # like IAM that do not have a specific region.\r\n  c.display_as        = :global\r\n  # deep_inspection works with set_data to automically collect\r\n  # data fields for each alert. Not required.\r\n  c.deep_inspection   = [:users]\r\nend\r\n\r\n# Required perform method\r\ndef perform(aws)\r\n  list_users = aws.iam.list_users\r\n  count = list_users[:users].count\r\n\r\n  # Set data for deep_inspection to use\r\n  set_data(list_users)\r\n\r\n  if count == 0\r\n    fail(user_count: count, condition: 'count == 0')\r\n  else\r\n    pass(user_count: count, condition: 'count >= 1')\r\n  end\r\nend\r\n"
-    #   alerts = ESP::CustomSignature.run(external_account_id: 3, regions: ['us_east_1'], language: 'ruby', signature: signature)
-    def self.run(arguments = {})
-      arguments = arguments.with_indifferent_access
-      arguments[:regions] = Array(arguments[:regions])
-      new(arguments).run
-    end
-
-    # Run this custom signature instance.
-    # Returns a collection of alerts.
-    # Throws an error if not successful.
-    #
-    # ==== Parameters
-    #
-    # +arguments+ | Required | A hash of run arguments
-    #
-    # ===== Valid Arguments
-    #
-    # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-run-existing] for valid arguments
-    #
-    # ==== Example
-    #   custom_signature = ESP::CustomSignature.find(365)
-    #   alerts = custom_signature.run!(external_account_id: 3, regions: ['us_east_1'])
-    def run!(arguments = {})
-      result = run(arguments)
-      return result if result.is_a?(ActiveResource::Collection)
-      self.message = errors.full_messages.join(' ')
-      fail(ActiveResource::ResourceInvalid.new(self)) # rubocop:disable Style/RaiseArgs
-    end
-
-    # Run this custom signature instance.
-    # Returns a collection of alerts.
-    # If not successful, returns a CustomSignature object with the errors object populated.
-    #
-    # ==== Parameters
-    #
-    # +arguments+ | Required | A hash of run arguments
-    #
-    # ===== Valid Arguments
-    #
-    # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-run-existing] for valid arguments
-    #
-    # ==== Example
-    #   custom_signature = ESP::CustomSignature.find(365)
-    #   alerts = custom_signature.run(external_account_id: 3, regions: ['us_east_1'])
-    def run(arguments = {})
-      arguments = arguments.with_indifferent_access
-
-      attributes['external_account_id'] ||= arguments[:external_account_id]
-      attributes['regions'] ||= Array(arguments[:regions])
-
-      response = connection.post endpoint, to_json
-      ESP::Alert.send(:instantiate_collection, self.class.format.decode(response.body))
-    rescue ActiveResource::BadRequest, ActiveResource::ResourceInvalid, ActiveResource::ResourceNotFound => error
-      load_remote_errors(error, true)
-      self.code = error.response.code
-      self
     end
 
     # Create a suppression for this custom signature.
@@ -175,8 +85,7 @@ module ESP
     #
     # ==== Example
     #
-    #  signature = "# Demo Ruby Signature\r\nconfigure do |c|\r\n  # Set regions to run in. Remove this line to run in all regions.\r\n  c.valid_regions     = [:us_east_1]\r\n  # Override region to display as global. Useful when checking resources\r\n  # like IAM that do not have a specific region.\r\n  c.display_as        = :global\r\n  # deep_inspection works with set_data to automically collect\r\n  # data fields for each alert. Not required.\r\n  c.deep_inspection   = [:users]\r\nend\r\n\r\n# Required perform method\r\ndef perform(aws)\r\n  list_users = aws.iam.list_users\r\n  count = list_users[:users].count\r\n\r\n  # Set data for deep_inspection to use\r\n  set_data(list_users)\r\n\r\n  if count == 0\r\n    fail(user_count: count, condition: 'count == 0')\r\n  else\r\n    pass(user_count: count, condition: 'count >= 1')\r\n  end\r\nend\r\n"
-    #  custom_signature = ESP::CustomSignature.create(signature: signature, description: "A test custom signature.", identifier: "AWS::IAM::001", language: "ruby", name: "Test Signature", risk_level: "Medium")
+    #  custom_signature = ESP::CustomSignature.create(description: "A test custom signature.", identifier: "AWS::IAM::001", name: "Test Signature", risk_level: "Medium")
 
     # :method: save
     # Create or update a CustomSignature
@@ -187,21 +96,10 @@ module ESP
     #
     # ==== Example
     #
-    #  signature = "# Demo Ruby Signature\r\nconfigure do |c|\r\n  # Set regions to run in. Remove this line to run in all regions.\r\n  c.valid_regions     = [:us_east_1]\r\n  # Override region to display as global. Useful when checking resources\r\n  # like IAM that do not have a specific region.\r\n  c.display_as        = :global\r\n  # deep_inspection works with set_data to automically collect\r\n  # data fields for each alert. Not required.\r\n  c.deep_inspection   = [:users]\r\nend\r\n\r\n# Required perform method\r\ndef perform(aws)\r\n  list_users = aws.iam.list_users\r\n  count = list_users[:users].count\r\n\r\n  # Set data for deep_inspection to use\r\n  set_data(list_users)\r\n\r\n  if count == 0\r\n    fail(user_count: count, condition: 'count == 0')\r\n  else\r\n    pass(user_count: count, condition: 'count >= 1')\r\n  end\r\nend\r\n"
-    #  custom_signature = ESP::CustomSignature.new(signature: signature, description: "A test custom signature.", identifier: "AWS::IAM::001", language: "ruby", name: "Test Signature", risk_level: "Medium")
+    #  custom_signature = ESP::CustomSignature.new(description: "A test custom signature.", identifier: "AWS::IAM::001", name: "Test Signature", risk_level: "Medium")
     #  custom_signature.save
 
     # :method: destroy
     # Delete a CustomSignature
-
-    private
-
-    def endpoint
-      if id.present?
-        "#{self.class.prefix}custom_signatures/#{id}/run.json"
-      else
-        "#{self.class.prefix}custom_signatures/run.json"
-      end
-    end
   end
 end

--- a/lib/esp/resources/custom_signature/definition.rb
+++ b/lib/esp/resources/custom_signature/definition.rb
@@ -1,0 +1,100 @@
+module ESP
+  class CustomSignature
+    class Definition < ESP::Resource
+      self.prefix += "custom_signature_"
+
+      belongs_to :custom_signature, class_name: 'ESP::CustomSignature'
+      has_many :results, class_name: 'ESP::CustomSignature::Result'
+
+      def activate
+        patch(:activate).tap do |response|
+          load_attributes_from_response(response)
+        end
+      rescue ActiveResource::BadRequest, ActiveResource::ResourceInvalid, ActiveResource::UnauthorizedAccess => error
+        load_remote_errors(error, true)
+        self.code = error.response.code
+        false
+      end
+
+      def archive
+        patch(:archive).tap do |response|
+          load_attributes_from_response(response)
+        end
+      rescue ActiveResource::BadRequest, ActiveResource::ResourceInvalid, ActiveResource::UnauthorizedAccess => error
+        load_remote_errors(error, true)
+        self.code = error.response.code
+        false
+      end
+
+      # :singleton-method: where
+      # Return a paginated CustomSignature::Definition list filtered by search parameters
+      #
+      # ==== Parameters
+      #
+      # +clauses+ | Hash of attributes with appended predicates to search, sort and include.
+      #
+      # ===== Valid Clauses
+      #
+      # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-definition-attributes] for valid arguments
+      #
+      # :call-seq:
+      #  where(clauses = {})
+
+      ##
+      # :singleton-method: find
+      # Find a CustomSignature::Definition by id
+      #
+      # ==== Parameter
+      #
+      # +id+ | Required | The ID of the custom signature definition to retrieve
+      #
+      # +options+ | Optional | A hash of options
+      #
+      # ===== Valid Options
+      #
+      # +include+ | The list of associated objects to return on the initial request.
+      #
+      # ===== Valid Includable Associations
+      #
+      # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-definition-attributes] for valid arguments
+      #
+      # :call-seq:
+      #  find(id, options = {})
+
+      # :singleton-method: all
+      # Return a paginated CustomSignature::Definition list
+
+      # :singleton-method: create
+      # Create a CustomSignature::Definition
+      # :call-seq:
+      #   create(attributes={})
+      #
+      # ==== Parameter
+      #
+      # +attributes+ | Required | A hash of custom signature definition attributes
+      #
+      # ===== Valid Attributes
+      #
+      # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-definition-create] for valid arguments
+      #
+      # ==== Example
+      #
+      #  definition = ESP::CustomSignature::Definition.create(custom_signature_id: 1)
+
+      # :method: save
+      # Create or update a CustomSignature::Definition
+      #
+      # ===== Valid Attributes
+      #
+      # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-definition-create] for valid arguments
+      #
+      # ==== Example
+      #
+      #  definition = ESP::CustomSignature::Definition.new(custom_signature_id: 1)
+      #  definition.save
+
+      # :method: destroy
+      # Delete a CustomSignature::Definition
+    end
+  end
+end

--- a/lib/esp/resources/custom_signature/result.rb
+++ b/lib/esp/resources/custom_signature/result.rb
@@ -1,0 +1,97 @@
+module ESP
+  class CustomSignature
+    class Result < ESP::Resource
+      autoload :Alert, File.expand_path(File.dirname(__FILE__) + '/result/alert')
+
+      self.prefix += "custom_signature_"
+
+      belongs_to :definition, class_name: 'ESP::CustomSignature::Definition', foreign_key: :definition_id
+      belongs_to :region, class_name: 'ESP::Region'
+      belongs_to :external_account, class_name: 'ESP::ExternalAccount'
+
+      def alerts
+        return attributes['alerts'] if attributes['alerts'].present?
+        CustomSignature::Result::Alert.for_result(id)
+      end
+
+      # Not Implemented. You cannot update a CustomSignature::Result.
+      def update
+        fail ESP::NotImplementedError
+      end
+
+      # Not Implemented. You cannot destroy a CustomSignature::Result.
+      def destroy
+        fail ESP::NotImplementedError
+      end
+
+      # :singleton-method: where
+      # Return a paginated CustomSignature::Result list filtered by search parameters
+      #
+      # ==== Parameters
+      #
+      # +clauses+ | Hash of attributes with appended predicates to search, sort and include.
+      #
+      # ===== Valid Clauses
+      #
+      # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-result-attributes] for valid arguments
+      #
+      # :call-seq:
+      #  where(clauses = {})
+
+      ##
+      # :singleton-method: find
+      # Find a CustomSignature::Result by id
+      #
+      # ==== Parameter
+      #
+      # +id+ | Required | The ID of the custom signature result to retrieve
+      #
+      # +options+ | Optional | A hash of options
+      #
+      # ===== Valid Options
+      #
+      # +include+ | The list of associated objects to return on the initial request.
+      #
+      # ===== Valid Includable Associations
+      #
+      # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-result-attributes] for valid arguments
+      #
+      # :call-seq:
+      #  find(id, options = {})
+
+      # :singleton-method: all
+      # Return a paginated CustomSignature::Result list
+
+      # :singleton-method: create
+      # Create a CustomSignature::Result
+      # :call-seq:
+      #   create(attributes={})
+      #
+      # ==== Parameter
+      #
+      # +attributes+ | Required | A hash of custom signature result attributes
+      #
+      # ===== Valid Attributes
+      #
+      # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-result-create] for valid arguments
+      #
+      # ==== Example
+      #
+      #  signature = "# Demo Ruby Signature\r\nconfigure do |c|\r\n  # Set regions to run in. Remove this line to run in all regions.\r\n  c.valid_regions     = [:us_east_1]\r\n  # Override region to display as global. Useful when checking resources\r\n  # like IAM that do not have a specific region.\r\n  c.display_as        = :global\r\n  # deep_inspection works with set_data to automically collect\r\n  # data fields for each alert. Not required.\r\n  c.deep_inspection   = [:users]\r\nend\r\n\r\n# Required perform method\r\ndef perform(aws)\r\n  list_users = aws.iam.list_users\r\n  count = list_users[:users].count\r\n\r\n  # Set data for deep_inspection to use\r\n  set_data(list_users)\r\n\r\n  if count == 0\r\n    fail(user_count: count, condition: 'count == 0')\r\n  else\r\n    pass(user_count: count, condition: 'count >= 1')\r\n  end\r\nend\r\n"
+      #  result = ESP::CustomSignature::Result.create(signature: signature, language: "ruby", region_id: 1, external_account_id: 1)
+
+      # :method: save
+      # Create or update a CustomSignature::Result
+      #
+      # ===== Valid Attributes
+      #
+      # See {API documentation}[http://api-docs.evident.io?ruby#custom-signature-result-create] for valid arguments
+      #
+      # ==== Example
+      #
+      #  signature = "# Demo Ruby Signature\r\nconfigure do |c|\r\n  # Set regions to run in. Remove this line to run in all regions.\r\n  c.valid_regions     = [:us_east_1]\r\n  # Override region to display as global. Useful when checking resources\r\n  # like IAM that do not have a specific region.\r\n  c.display_as        = :global\r\n  # deep_inspection works with set_data to automically collect\r\n  # data fields for each alert. Not required.\r\n  c.deep_inspection   = [:users]\r\nend\r\n\r\n# Required perform method\r\ndef perform(aws)\r\n  list_users = aws.iam.list_users\r\n  count = list_users[:users].count\r\n\r\n  # Set data for deep_inspection to use\r\n  set_data(list_users)\r\n\r\n  if count == 0\r\n    fail(user_count: count, condition: 'count == 0')\r\n  else\r\n    pass(user_count: count, condition: 'count >= 1')\r\n  end\r\nend\r\n"
+      #  result = ESP::CustomSignature::Result.new(signature: signature, language: "ruby", region_id: 1, external_account_id: 1)
+      #  result.save
+    end
+  end
+end

--- a/lib/esp/resources/custom_signature/result/alert.rb
+++ b/lib/esp/resources/custom_signature/result/alert.rb
@@ -15,7 +15,7 @@ module ESP
         # See {API documentation}[http://api-docs.evident.io?ruby#alert-attributes] for valid arguments
         def self.for_result(custom_signature_result_id = nil)
           fail ArgumentError, "You must supply a custom signature result id." unless custom_signature_result_id.present?
-          # call find_one directly since find is overriden/not implemented
+          # call find_every directly since find is overriden/not implemented
           find_every(from: "#{prefix}custom_signature_results/#{custom_signature_result_id}/alerts.json")
         end
 

--- a/lib/esp/resources/custom_signature/result/alert.rb
+++ b/lib/esp/resources/custom_signature/result/alert.rb
@@ -1,0 +1,53 @@
+module ESP
+  class CustomSignature
+    class Result
+      class Alert < ESP::Resource
+        belongs_to :region, class_name: 'ESP::Region'
+        belongs_to :external_account, class_name: 'ESP::ExternalAccount'
+        belongs_to :custom_signature, class_name: 'ESP::CustomSignature'
+
+        # Returns all the alerts for a custom signature result identified by the custom_signature_result_id parameter.
+        #
+        # ==== Parameters
+        #
+        # +custom_signature_result_id+ | Required | The ID of the custom signature result to retrieve alerts for
+        #
+        # See {API documentation}[http://api-docs.evident.io?ruby#alert-attributes] for valid arguments
+        def self.for_result(custom_signature_result_id = nil)
+          fail ArgumentError, "You must supply a custom signature result id." unless custom_signature_result_id.present?
+          # call find_one directly since find is overriden/not implemented
+          find_every(from: "#{prefix}custom_signature_results/#{custom_signature_result_id}/alerts.json")
+        end
+
+        # Not Implemented. You cannot search for CustomSignature::Result::Alert.
+        #
+        # Regular ARELlike methods are disabled.
+        def self.find(*)
+          fail ESP::NotImplementedError, 'Regular ARELlike methods are disabled. Use the .for_result method.'
+        end
+
+        # Not Implemented. You cannot search for CustomSignature::Result::Alert.
+        #
+        # Regular ARELlike methods are disabled.
+        def self.where(*)
+          fail ESP::NotImplementedError, 'Regular ARELlike methods are disabled. Use the .for_result method.'
+        end
+
+        # Not Implemented. You cannot create a CustomSignature::Result::Alert.
+        def create
+          fail ESP::NotImplementedError
+        end
+
+        # Not Implemented. You cannot update a CustomSignature::Result::Alert.
+        def update
+          fail ESP::NotImplementedError
+        end
+
+        # Not Implemented. You cannot destroy a CustomSignature::Result::Alert.
+        def destroy
+          fail ESP::NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/esp/resources/dashboard.rb
+++ b/lib/esp/resources/dashboard.rb
@@ -1,13 +1,13 @@
 module ESP
   class Dashboard < ESP::Resource
-    # Not Implemented. You cannot search for Suppression::Region.
+    # Not Implemented. You cannot search for a Dashboard.
     #
     # Regular ARELlike methods are disabled.
     def self.find(*)
       fail ESP::NotImplementedError, 'Regular ARELlike methods are disabled.  Use the .recent method.'
     end
 
-    # Not Implemented. You cannot search for Suppression::Region.
+    # Not Implemented. You cannot search for a Dashboard.
     #
     # Regular ARELlike methods are disabled.
     def self.where(*)

--- a/lib/esp/resources/report.rb
+++ b/lib/esp/resources/report.rb
@@ -1,5 +1,9 @@
 module ESP
   class Report < ESP::Resource
+    module Export
+      autoload :Integration, File.expand_path(File.dirname(__FILE__) + '/reports/export/integration')
+    end
+
     ##
     # The organization the report belongs to.
     belongs_to :organization, class_name: 'ESP::Organization'
@@ -12,7 +16,7 @@ module ESP
     # The team the report belongs to.
     belongs_to :team, class_name: 'ESP::Team'
 
-    # Not Implemented. You cannot create or update a Report.
+    # Not Implemented. You cannot update a Report.
     def update
       fail ESP::NotImplementedError
     end

--- a/lib/esp/resources/suppression.rb
+++ b/lib/esp/resources/suppression.rb
@@ -1,5 +1,9 @@
 module ESP
   class Suppression < ESP::Resource
+    autoload :UniqueIdentifier, File.expand_path(File.dirname(__FILE__) + '/suppression/unique_identifier')
+    autoload :Signature, File.expand_path(File.dirname(__FILE__) + '/suppression/signature')
+    autoload :Region, File.expand_path(File.dirname(__FILE__) + '/suppression/region')
+
     ##
     # The organization this sub organization belongs to.
     belongs_to :organization, class_name: 'ESP::Organization'

--- a/test/esp/integration/custom_signature_definition_integration_test.rb
+++ b/test/esp/integration/custom_signature_definition_integration_test.rb
@@ -1,0 +1,95 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+
+module ESP::Integration
+  class CustomSignatureDefinitionTest < ESP::Integration::TestCase
+    context ESP::CustomSignature::Definition do
+      context 'live calls' do
+        context '#custom_signature' do
+          should 'return a custom_signature' do
+            archived_definition = ESP::CustomSignature::Definition.where(status_eq: 'archived').last
+            fail 'Missing definition' if archived_definition.blank?
+
+            custom_signature = archived_definition.custom_signature
+
+            assert_equal archived_definition.custom_signature_id, custom_signature.id
+            assert_equal ESP::CustomSignature, custom_signature.class
+          end
+        end
+
+        context '#results' do
+          should 'return list of results' do
+            archived_definition = ESP::CustomSignature::Definition.where(status_eq: 'archived').last
+            fail 'Missing definition' if archived_definition.blank?
+
+            results = archived_definition.results
+
+            assert_equal ESP::CustomSignature::Result, results.resource_class
+          end
+        end
+
+        context '.where' do
+          should 'return definition objects' do
+            archived_definition = ESP::CustomSignature::Definition.where(status_eq: 'archived').last
+            fail 'Missing definition' if archived_definition.blank?
+
+            definitions = ESP::CustomSignature::Definition.where(id_eq: archived_definition.id)
+
+            assert_equal ESP::CustomSignature::Definition, definitions.resource_class
+          end
+        end
+
+        context '.archive' do
+          should 'archive definition' do
+            definition = ESP::CustomSignature::Definition.where(status_eq: 'active').last
+            fail 'Missing definition' if definition.blank?
+
+            definition.archive
+
+            assert_equal 'archived', definition.status
+          end
+        end
+
+        context '.activate' do
+          should 'activate definition' do
+            custom_signature = ESP::CustomSignature.last
+            fail 'Missing custom signature' if custom_signature.blank?
+            definition = ESP::CustomSignature::Definition.create(custom_signature_id: custom_signature.id)
+
+            assert_equal 'editable', definition.status
+
+            definition.activate
+
+            assert_equal 'validating', definition.status
+          end
+        end
+
+        context '#CRUD' do
+          should 'be able to create, update and destroy' do
+            custom_signature = ESP::CustomSignature.last
+            fail 'Missing custom signature' if custom_signature.blank?
+            definition = ESP::CustomSignature::Definition.new(custom_signature_id: custom_signature.id)
+
+            assert_predicate definition, :new?
+
+            definition.save
+
+            refute_predicate definition, :new?
+
+            definition.code = 'ABC123'
+            definition.save
+
+            assert_nothing_raised do
+              ESP::CustomSignature::Definition.find(definition.id)
+            end
+
+            definition.destroy
+
+            assert_raises ActiveResource::ResourceNotFound do
+              ESP::CustomSignature::Definition.find(definition.id)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/esp/integration/custom_signature_integration_test.rb
+++ b/test/esp/integration/custom_signature_integration_test.rb
@@ -26,38 +26,6 @@ module ESP::Integration
           end
         end
 
-        context '.run' do
-          should 'return alerts' do
-            skip "Can't run sigs on CI" if ENV['CI_SERVER']
-            external_account_id = ESP::ExternalAccount.last.id
-            alerts = ESP::CustomSignature.run(external_account_id: external_account_id, regions: 'us_east_1', language: @custom_signature.language, signature: @custom_signature.signature)
-
-            assert_equal ESP::Alert, alerts.resource_class
-          end
-
-          should 'return errors' do
-            signature = ESP::CustomSignature.run(external_account_id: 999_999_999_999, regions: 'us_east_1', language: @custom_signature.language, signature: @custom_signature.signature)
-
-            assert_equal "Couldn't find ExternalAccount", signature.errors.full_messages.first
-          end
-        end
-
-        context '#run' do
-          should 'return alerts' do
-            skip "Can't run sigs on CI" if ENV['CI_SERVER']
-            external_account_id = ESP::ExternalAccount.last.id
-            alerts = @custom_signature.run(external_account_id: external_account_id, regions: ['us_east_1'])
-
-            assert_equal ESP::Alert, alerts.resource_class
-          end
-
-          should 'return errors' do
-            @custom_signature.run(external_account_id: 999_999_999_999)
-
-            assert_equal "Couldn't find ExternalAccount", @custom_signature.errors.full_messages.first
-          end
-        end
-
         context '.where' do
           should 'return custom_signature objects' do
             custom_signatures = ESP::CustomSignature.where(id_eq: @custom_signature.id)
@@ -68,7 +36,6 @@ module ESP::Integration
 
         context '#CRUD' do
           should 'be able to create, update and destroy' do
-            skip "Can't run sigs on CI" if ENV['CI_SERVER']
             custom_signature = ESP::CustomSignature.new(@custom_signature.attributes)
 
             assert_predicate custom_signature, :new?

--- a/test/esp/integration/custom_signature_result_alert_integration_test.rb
+++ b/test/esp/integration/custom_signature_result_alert_integration_test.rb
@@ -1,0 +1,59 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+
+module ESP::Integration
+  class CustomSignatureResultAlertTest < ESP::Integration::TestCase
+    context ESP::CustomSignature::Result::Alert do
+      context 'live calls' do
+        context '#for_result' do
+          should 'return alerts' do
+            result = ESP::CustomSignature::Result.first
+            fail 'Missing result' if result.blank?
+
+            alerts = ESP::CustomSignature::Result::Alert.for_result(result.id)
+
+            assert_equal ESP::CustomSignature::Result::Alert, alerts.resource_class
+          end
+        end
+
+        context '#custom_signature' do
+          should 'return a custom_signature' do
+            result = ESP::CustomSignature::Result.first
+            fail 'Missing result' if result.blank?
+            alert = ESP::CustomSignature::Result::Alert.for_result(result.id).first
+
+            custom_signature = alert.custom_signature
+
+            assert_equal ESP::CustomSignature, custom_signature.class
+            assert_equal alert.custom_signature_id, custom_signature.id
+          end
+        end
+
+        context '#external_account' do
+          should 'return a external_account' do
+            result = ESP::CustomSignature::Result.first
+            fail 'Missing result' if result.blank?
+            alert = ESP::CustomSignature::Result::Alert.for_result(result.id).first
+
+            external_account = alert.external_account
+
+            assert_equal ESP::ExternalAccount, external_account.class
+            assert_equal alert.external_account_id, external_account.id
+          end
+        end
+
+        context '#region' do
+          should 'return a region' do
+            result = ESP::CustomSignature::Result.first
+            fail 'Missing result' if result.blank?
+            alert = ESP::CustomSignature::Result::Alert.for_result(result.id).first
+
+            region = alert.region
+
+            assert_equal ESP::Region, region.class
+            assert_equal alert.region_id, region.id
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/esp/integration/custom_signature_result_integration_test.rb
+++ b/test/esp/integration/custom_signature_result_integration_test.rb
@@ -1,0 +1,83 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+
+module ESP::Integration
+  class CustomSignatureResultTest < ESP::Integration::TestCase
+    context ESP::CustomSignature::Result do
+      context 'live calls' do
+        context '#definition' do
+          should 'return a definition' do
+            result = ESP::CustomSignature::Result.last
+            fail 'Missing result' if result.blank?
+
+            definition = result.definition
+
+            assert_equal ESP::CustomSignature::Definition, definition.class
+            assert_equal result.definition_id, definition.id
+          end
+        end
+
+        context '#region' do
+          should 'return a region' do
+            result = ESP::CustomSignature::Result.last
+            fail 'Missing result' if result.blank?
+
+            region = result.region
+
+            assert_equal ESP::Region, region.class
+            assert_equal result.region_id, region.id
+          end
+        end
+
+        context '#external_account' do
+          should 'return a external_account' do
+            result = ESP::CustomSignature::Result.last
+            fail 'Missing result' if result.blank?
+
+            external_account = result.external_account
+
+            assert_equal ESP::ExternalAccount, external_account.class
+            assert_equal result.external_account_id, external_account.id
+          end
+        end
+
+        context '#alerts' do
+          should 'return list of alerts' do
+            result = ESP::CustomSignature::Result.last
+            fail 'Missing result' if result.blank?
+
+            alerts = result.alerts
+
+            assert_equal ESP::CustomSignature::Result::Alert, alerts.resource_class
+          end
+        end
+
+        context '.where' do
+          should 'return result objects' do
+            result = ESP::CustomSignature::Result.last
+            fail 'Missing result' if result.blank?
+
+            results = ESP::CustomSignature::Result.where(id_eq: result.id)
+
+            assert_equal ESP::CustomSignature::Result, results.resource_class
+          end
+        end
+
+        context '#create' do
+          should 'be able to create' do
+            custom_signature = ESP::CustomSignature.create(name: 'ABC', identifier: 'ABC', risk_level: 'High')
+            refute_predicate custom_signature, :new?
+            definition = custom_signature.definitions.first
+            fail 'Missing definition' if definition.blank?
+            result = ESP::CustomSignature::Result.new(custom_signature_definition_id: definition.id, external_account_id: 1, region_id: 1, code: 'abc', language: 'ruby')
+
+            assert_predicate result, :new?
+
+            result.save
+
+            refute_predicate result, :new?
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/esp/integration/external_account_integration_test.rb
+++ b/test/esp/integration/external_account_integration_test.rb
@@ -40,28 +40,6 @@ module ESP::Integration
             assert_equal ESP::ExternalAccount, external_accounts.resource_class
           end
         end
-
-        context '#CRUD' do
-          should 'be able to create, update and destroy' do
-            skip "There are to many dependencies to validate an external account to create or update one. Besides esp_web, esp_query has to be running and there must be valid AWS keys assigned as well."
-
-            external_account = ESP::ExternalAccount.create(name: 'bob', arn: @external_account.arn, sub_organization_id: @external_account.sub_organization_id, team_id: @external_account.team_id)
-
-            assert_predicate external_account, :new?
-            assert_contains external_account.errors, "The account for this ARN is already being checked by Dev"
-
-            refute_predicate @external_account, :new?
-            @external_account.name = @external_account.name
-
-            assert_predicate @external_account, :save
-
-            external_account = build(:external_account, id: 999)
-
-            assert_raises ActiveResource::ResourceNotFound do
-              external_account.destroy
-            end
-          end
-        end
       end
     end
   end

--- a/test/esp/integration/report_export_integration_integration_test.rb
+++ b/test/esp/integration/report_export_integration_integration_test.rb
@@ -7,7 +7,7 @@ module ESP::Integration
         context ESP::Report::Export::Integration do
           context 'live calls' do
             context '#create' do
-              should 'return regions' do
+              should 'queue export' do
                 report = ESP::Report.last
                 fail "Live DB does not have any reports.  Add a report with stats and run tests again." if report.blank?
 

--- a/test/esp/resources/custom_signature/definition_test.rb
+++ b/test/esp/resources/custom_signature/definition_test.rb
@@ -1,0 +1,55 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../../test_helper')
+
+module ESP
+  class CustomSignature
+    class DefinitionTest < ActiveSupport::TestCase
+      context ESP::CustomSignature::Definition do
+        context '#custom_signature' do
+          should 'call the api' do
+            definition = build(:definition, custom_signature_id: 4)
+            stubbed_custom_signature = stub_request(:get, %r{custom_signatures/#{definition.custom_signature_id}.json*}).to_return(body: json(:custom_signature))
+
+            definition.custom_signature
+
+            assert_requested(stubbed_custom_signature)
+          end
+        end
+
+        context '#results' do
+          should 'call the api' do
+            definition = build(:definition)
+            stub_request(:get, /custom_signature_results.json*/).to_return(body: json_list(:result, 2))
+
+            definition.results
+
+            assert_requested(:get, /custom_signature_results.json*/) do |req|
+              assert_equal "filter[definition_id_eq]=#{definition.id}", URI.unescape(req.uri.query)
+            end
+          end
+        end
+
+        context 'activate' do
+          should 'call the api' do
+            definition = build(:definition)
+            stubbed_defintion = stub_request(:patch, %r{custom_signature_definitions/#{definition.id}/activate.json}).to_return(body: json(:definition))
+
+            definition.activate
+
+            assert_requested stubbed_defintion
+          end
+        end
+
+        context 'archive' do
+          should 'call the api' do
+            definition = build(:definition)
+            stubbed_defintion = stub_request(:patch, %r{custom_signature_definitions/#{definition.id}/archive.json}).to_return(body: json(:definition))
+
+            definition.archive
+
+            assert_requested stubbed_defintion
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/esp/resources/custom_signature/definition_test.rb
+++ b/test/esp/resources/custom_signature/definition_test.rb
@@ -37,6 +37,17 @@ module ESP
 
             assert_requested stubbed_defintion
           end
+
+          should 'parse errors' do
+            definition = build(:definition)
+            stub_request(:patch, %r{custom_signature_definitions/#{definition.id}/activate.json}).to_return(status: 422, body: json(:error, :active_record))
+
+            definition.activate
+
+            assert_contains definition.errors.full_messages, "Name can't be blank"
+            assert_contains definition.errors.full_messages, "Name is invalid"
+            assert_contains definition.errors.full_messages, "Description can't be blank"
+          end
         end
 
         context 'archive' do
@@ -47,6 +58,17 @@ module ESP
             definition.archive
 
             assert_requested stubbed_defintion
+          end
+
+          should 'parse errors' do
+            definition = build(:definition)
+            stub_request(:patch, %r{custom_signature_definitions/#{definition.id}/archive.json}).to_return(status: 422, body: json(:error, :active_record))
+
+            definition.archive
+
+            assert_contains definition.errors.full_messages, "Name can't be blank"
+            assert_contains definition.errors.full_messages, "Name is invalid"
+            assert_contains definition.errors.full_messages, "Description can't be blank"
           end
         end
       end

--- a/test/esp/resources/custom_signature/result/alert_test.rb
+++ b/test/esp/resources/custom_signature/result/alert_test.rb
@@ -37,6 +37,46 @@ module ESP
               assert_requested(stubbed_custom_signature)
             end
           end
+
+          context '.find' do
+            should 'raise ESP::NotImplementedError' do
+              assert_raises ESP::NotImplementedError do
+                ESP::CustomSignature::Result::Alert.find(1)
+              end
+            end
+          end
+
+          context '.where' do
+            should 'raise ESP::NotImplementedError' do
+              assert_raises ESP::NotImplementedError do
+                ESP::CustomSignature::Result::Alert.where(id_eq: 1)
+              end
+            end
+          end
+
+          context '#create' do
+            should 'raise ESP::NotImplementedError' do
+              assert_raises ESP::NotImplementedError do
+                ESP::CustomSignature::Result::Alert.new.create
+              end
+            end
+          end
+
+          context '#update' do
+            should 'raise ESP::NotImplementedError' do
+              assert_raises ESP::NotImplementedError do
+                ESP::CustomSignature::Result::Alert.new.update
+              end
+            end
+          end
+
+          context '#destroy' do
+            should 'raise ESP::NotImplementedError' do
+              assert_raises ESP::NotImplementedError do
+                ESP::CustomSignature::Result::Alert.new.destroy
+              end
+            end
+          end
         end
       end
     end

--- a/test/esp/resources/custom_signature/result/alert_test.rb
+++ b/test/esp/resources/custom_signature/result/alert_test.rb
@@ -1,0 +1,44 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../../../test_helper')
+
+module ESP
+  class CustomSignature
+    class Result
+      class AlertTest < ActiveSupport::TestCase
+        context ESP::CustomSignature::Result::Alert do
+          context '#region' do
+            should 'call the api' do
+              alert = build(:result_alert, region_id: 4)
+              stubbed_region = stub_request(:get, %r{regions/#{alert.region_id}.json*}).to_return(body: json(:region))
+
+              alert.region
+
+              assert_requested(stubbed_region)
+            end
+          end
+
+          context '#external_account' do
+            should 'call the api' do
+              alert = build(:result_alert, external_account_id: 4)
+              stubbed_external_account = stub_request(:get, %r{external_accounts/#{alert.external_account_id}.json*}).to_return(body: json(:external_account))
+
+              alert.external_account
+
+              assert_requested(stubbed_external_account)
+            end
+          end
+
+          context '#custom_signature' do
+            should 'call the api' do
+              alert = build(:result_alert, custom_signature_id: 4)
+              stubbed_custom_signature = stub_request(:get, %r{custom_signatures/#{alert.custom_signature_id}.json*}).to_return(body: json(:custom_signature))
+
+              alert.custom_signature
+
+              assert_requested(stubbed_custom_signature)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/esp/resources/custom_signature/result_test.rb
+++ b/test/esp/resources/custom_signature/result_test.rb
@@ -6,8 +6,8 @@ module ESP
       context ESP::CustomSignature::Result do
         context '#definition' do
           should 'call the api' do
-            result = build(:result, custom_signature_definition_id: 4)
-            stubbed_definition = stub_request(:get, %r{custom_signature_definitions/#{result.custom_signature_definition_id}.json*}).to_return(body: json(:definition))
+            result = build(:result, definition_id: 4)
+            stubbed_definition = stub_request(:get, %r{custom_signature_definitions/#{result.definition_id}.json*}).to_return(body: json(:definition))
 
             result.definition
 

--- a/test/esp/resources/custom_signature/result_test.rb
+++ b/test/esp/resources/custom_signature/result_test.rb
@@ -1,0 +1,75 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../../test_helper')
+
+module ESP
+  class CustomSignature
+    class ResultTest < ActiveSupport::TestCase
+      context ESP::CustomSignature::Result do
+        context '#definition' do
+          should 'call the api' do
+            result = build(:result, custom_signature_definition_id: 4)
+            stubbed_definition = stub_request(:get, %r{custom_signature_definitions/#{result.custom_signature_definition_id}.json*}).to_return(body: json(:definition))
+
+            result.definition
+
+            assert_requested(stubbed_definition)
+          end
+        end
+
+        context '#region' do
+          should 'call the api' do
+            result = build(:result, region_id: 4)
+            stubbed_region = stub_request(:get, %r{regions/#{result.region_id}.json*}).to_return(body: json(:region))
+
+            result.region
+
+            assert_requested(stubbed_region)
+          end
+        end
+
+        context '#external_account' do
+          should 'call the api' do
+            result = build(:result, external_account_id: 4)
+            stubbed_external_account = stub_request(:get, %r{external_accounts/#{result.external_account_id}.json*}).to_return(body: json(:external_account))
+
+            result.external_account
+
+            assert_requested(stubbed_external_account)
+          end
+        end
+
+        context '#alerts' do
+          should 'call the api' do
+            result = build(:result)
+            stub_request(:get, %r{custom_signature_results/#{result.id}/alerts.json}).to_return(body: json_list(:result_alert, 2))
+
+            result.alerts
+
+            assert_requested(:get, %r{custom_signature_results/#{result.id}/alerts.json})
+          end
+        end
+
+        context 'activate' do
+          should 'call the api' do
+            definition = build(:definition)
+            stubbed_defintion = stub_request(:patch, %r{custom_signature_definitions/#{definition.id}/activate.json}).to_return(body: json(:definition))
+
+            definition.activate
+
+            assert_requested stubbed_defintion
+          end
+        end
+
+        context 'archive' do
+          should 'call the api' do
+            definition = build(:definition)
+            stubbed_defintion = stub_request(:patch, %r{custom_signature_definitions/#{definition.id}/archive.json}).to_return(body: json(:definition))
+
+            definition.archive
+
+            assert_requested stubbed_defintion
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/esp/resources/custom_signature/result_test.rb
+++ b/test/esp/resources/custom_signature/result_test.rb
@@ -69,6 +69,22 @@ module ESP
             assert_requested stubbed_defintion
           end
         end
+
+        context '#update' do
+          should 'raise ESP::NotImplementedError' do
+            assert_raises ESP::NotImplementedError do
+              ESP::CustomSignature::Result::Alert.new.update
+            end
+          end
+        end
+
+        context '#destroy' do
+          should 'raise ESP::NotImplementedError' do
+            assert_raises ESP::NotImplementedError do
+              ESP::CustomSignature::Result::Alert.new.destroy
+            end
+          end
+        end
       end
     end
   end

--- a/test/esp/resources/custom_signature_test.rb
+++ b/test/esp/resources/custom_signature_test.rb
@@ -28,130 +28,15 @@ module ESP
         end
       end
 
-      context '.run_sanity_test!' do
-        should 'call the api and pass params' do
-          custom_signature = build(:custom_signature, external_account_id: 3)
-          stub_request(:post, %r{custom_signatures/run.json*}).to_return(body: json_list(:alert, 2))
+      context '#definitions' do
+        should 'call the api' do
+          custom_signature = build(:custom_signature, team_id: 1)
+          stub_request(:get, /custom_signature_definitions.json*/).to_return(body: json_list(:definition, 2))
 
-          alerts = ESP::CustomSignature.run!(external_account_id: 3, regions: 'param2', language: custom_signature.language, signature: custom_signature.signature)
+          custom_signature.definitions
 
-          assert_requested(:post, %r{custom_signatures/run.json*}) do |req|
-            body = JSON.parse req.body
-            assert_equal false, body['data'].key?('id')
-            assert_equal ['param2'], body['data']['attributes']['regions']
-            assert_equal custom_signature.language, body['data']['attributes']['language']
-            assert_equal custom_signature.signature, body['data']['attributes']['signature']
-          end
-          assert_equal ESP::Alert, alerts.resource_class
-        end
-
-        should 'throw an error if an error is returned' do
-          custom_signature = build(:custom_signature, external_account_id: 3)
-          error = ActiveResource::BadRequest.new('')
-          error_response = json(:error)
-          response = mock(body: error_response, code: '400')
-          error.stubs(:response).returns(response)
-          ActiveResource::Connection.any_instance.expects(:post).raises(error)
-          stub_request(:post, %r{custom_signatures/run.json*}).to_return(body: json_list(:alert, 2))
-
-          error = assert_raises ActiveResource::ResourceInvalid do
-            ESP::CustomSignature.run!(external_account_id: 3, regions: 'param2', language: custom_signature.language, signature: custom_signature.signature)
-          end
-          assert_equal "Failed.  Response code = 400.  Response message = #{JSON.parse(error_response)['errors'].first['title']}.", error.message
-        end
-      end
-
-      context '.run_sanity_test' do
-        should 'call the api and pass params' do
-          custom_signature = build(:custom_signature, external_account_id: 3)
-          stub_request(:post, %r{custom_signatures/run.json*}).to_return(body: json_list(:alert, 2))
-
-          alerts = ESP::CustomSignature.run(external_account_id: 3, regions: 'param2', language: custom_signature.language, signature: custom_signature.signature)
-
-          assert_requested(:post, %r{custom_signatures/run.json*}) do |req|
-            body = JSON.parse req.body
-            assert_equal false, body['data'].key?('id')
-            assert_equal ['param2'], body['data']['attributes']['regions']
-            assert_equal custom_signature.language, body['data']['attributes']['language']
-            assert_equal custom_signature.signature, body['data']['attributes']['signature']
-          end
-          assert_equal ESP::Alert, alerts.resource_class
-        end
-
-        should 'not throw an error if an error is returned' do
-          custom_signature = build(:custom_signature, external_account_id: 3)
-          error = ActiveResource::BadRequest.new('')
-          error_response = json(:error)
-          response = mock(body: error_response, code: '400')
-          error.stubs(:response).returns(response)
-          ActiveResource::Connection.any_instance.expects(:post).raises(error)
-          stub_request(:post, %r{custom_signatures/run.json*}).to_return(body: json_list(:alert, 2))
-
-          assert_nothing_raised do
-            result = ESP::CustomSignature.run(external_account_id: 3, regions: 'param2', language: custom_signature.language, signature: custom_signature.signature)
-            assert_equal JSON.parse(error_response)['errors'].first['title'], result.errors.full_messages.first
-          end
-        end
-      end
-
-      context '#run!' do
-        should 'call the api and pass params' do
-          custom_signature = build(:custom_signature, external_account_id: 3)
-          stub_request(:post, %r{custom_signatures/#{custom_signature.id}/run.json*}).to_return(body: json_list(:alert, 2))
-
-          alerts = custom_signature.run!(regions: 'param2')
-
-          assert_requested(:post, %r{custom_signatures/#{custom_signature.id}/run.json*}) do |req|
-            body = JSON.parse req.body
-            assert_equal custom_signature.id, body['data']['id']
-            assert_equal ['param2'], body['data']['attributes']['regions']
-          end
-          assert_equal ESP::Alert, alerts.resource_class
-        end
-
-        should 'throw an error if an error is returned' do
-          custom_signature = build(:custom_signature, external_account_id: 3)
-          error = ActiveResource::BadRequest.new('')
-          error_response = json(:error)
-          response = mock(body: error_response, code: '400')
-          error.stubs(:response).returns(response)
-          ActiveResource::Connection.any_instance.expects(:post).raises(error)
-          stub_request(:post, %r{custom_signatures/#{custom_signature.id}/run.json*}).to_return(body: json_list(:alert, 2))
-
-          error = assert_raises ActiveResource::ResourceInvalid do
-            custom_signature.run!(regions: 'param2')
-          end
-          assert_equal "Failed.  Response code = 400.  Response message = #{JSON.parse(error_response)['errors'].first['title']}.", error.message
-        end
-      end
-
-      context '#run' do
-        should 'call the api and pass params' do
-          custom_signature = build(:custom_signature, external_account_id: 3)
-          stub_request(:post, %r{custom_signatures/#{custom_signature.id}/run.json*}).to_return(body: json_list(:alert, 2))
-
-          alerts = custom_signature.run(regions: 'param2')
-
-          assert_requested(:post, %r{custom_signatures/#{custom_signature.id}/run.json*}) do |req|
-            body = JSON.parse req.body
-            assert_equal custom_signature.id, body['data']['id']
-            assert_equal ['param2'], body['data']['attributes']['regions']
-          end
-          assert_equal ESP::Alert, alerts.resource_class
-        end
-
-        should 'not throw an error if an error is returned' do
-          custom_signature = build(:custom_signature, external_account_id: 3)
-          error = ActiveResource::BadRequest.new('')
-          error_response = json(:error)
-          response = mock(body: error_response, code: '400')
-          error.stubs(:response).returns(response)
-          ActiveResource::Connection.any_instance.expects(:post).raises(error)
-          stub_request(:post, %r{custom_signatures/#{custom_signature.id}/run.json*}).to_return(body: json_list(:alert, 2))
-
-          assert_nothing_raised do
-            custom_signature.run(regions: 'param2')
-            assert_equal JSON.parse(error_response)['errors'].first['title'], custom_signature.errors.full_messages.first
+          assert_requested(:get, /custom_signature_definitions.json*/) do |req|
+            assert_equal "filter[custom_signature_id_eq]=#{custom_signature.id}", URI.unescape(req.uri.query)
           end
         end
       end

--- a/test/esp/resources/service_test.rb
+++ b/test/esp/resources/service_test.rb
@@ -24,6 +24,14 @@ module ESP
         end
       end
 
+      context '.where' do
+        should 'not be implemented' do
+          assert_raises ESP::NotImplementedError do
+            ESP::Service.where(id_eq: 1)
+          end
+        end
+      end
+
       context '#create' do
         should 'not be implemented' do
           assert_raises ESP::NotImplementedError do

--- a/test/factories/custom_signature/definitions.rb
+++ b/test/factories/custom_signature/definitions.rb
@@ -1,0 +1,30 @@
+FactoryGirl.define do
+  factory :definition, class: 'ESP::CustomSignature::Definition' do
+    skip_create
+
+    sequence(:id) { |n| n }
+    code 'abc'
+    created_at { Time.current }
+    language 'javascript'
+    status "active"
+    updated_at { Time.current }
+
+    relationships do
+      { custom_signature: {
+        data: {
+          type: "custom_signatures",
+          id: "1"
+        },
+        links: {
+          related: "http://localhost:3000/api/v2/custom_signatures/1.json"
+        }
+      },
+        results: {
+          links: {
+            related: "http://localhost:3000/api/v2/custom_signature_results.json?filter%5Bdefinition_id_eq%5D=#{id}"
+          }
+        }
+      }
+    end
+  end
+end

--- a/test/factories/custom_signature/result_alerts.rb
+++ b/test/factories/custom_signature/result_alerts.rb
@@ -1,0 +1,94 @@
+FactoryGirl.define do
+  factory :result_alert, class: 'ESP::CustomSignature::Result::Alert' do
+    skip_create
+
+    sequence(:id) { |n| n }
+    type "alerts"
+    created_at { Time.current }
+    status "fail"
+    resource "resource-3"
+    updated_at nil
+    started_at { Time.current }
+    ended_at nil
+    metadata { { abc: '123' } }
+    tags { [{ key: 'Name', value: 'i-abc123' }] }
+    relationships do
+      {
+        external_account: {
+          data: {
+            type: "external_accounts",
+            id: "1015"
+          },
+          links: {
+            related: "http://test.host/api/v2/external_accounts/1015.json"
+          }
+        },
+        region: {
+          data: {
+            type: "regions",
+            id: "1014"
+          }
+        },
+        custom_signature: {
+          data: nil
+        }
+      }
+    end
+    included do
+      [
+        {
+          id: "1015",
+          type: "external_accounts",
+          attributes: {
+            account: "5",
+            arn: "arn:aws:iam::5:role/test_sts_role",
+            created_at: "2015-09-11T21:12:15.183Z",
+            external_id: "test_sts_external_id_1",
+            name: nil,
+            updated_at: nil,
+            user_attribution_role: nil
+          },
+          relationships: {
+            organization: {
+              data: {
+                type: "organizations",
+                id: "5"
+              },
+              links: {
+                related: "http://test.host/api/v2/organizations/5.json"
+              }
+            },
+            sub_organization: {
+              data: {
+                type: "sub_organizations",
+                id: "5"
+              },
+              links: {
+                related: "http://test.host/api/v2/sub_organizations/5.json"
+              }
+            },
+            team: {
+              data: {
+                type: "teams",
+                id: "5"
+              },
+              links: {
+                related: "http://test.host/api/v2/teams/5.json"
+              }
+            },
+            user_attribution_role: {
+              data: nil
+            }
+          }
+        },
+        {
+          id: "1014",
+          type: "regions",
+          attributes: {
+            code: "us_east_test_3"
+          }
+        }
+      ]
+    end
+  end
+end

--- a/test/factories/custom_signature/results.rb
+++ b/test/factories/custom_signature/results.rb
@@ -1,0 +1,49 @@
+FactoryGirl.define do
+  factory :result, class: 'ESP::CustomSignature::Result' do
+    skip_create
+
+    sequence(:id) { |n| n }
+    code 'abc'
+    created_at { Time.current }
+    language 'javascript'
+    status "complete"
+    updated_at { Time.current }
+
+    relationships do
+      {
+        definition: {
+          data: {
+            type: "definitions",
+            id: "1"
+          },
+          links: {
+            related: "http://localhost:3000/api/v2/custom_signature_definitions/1.json"
+          }
+        },
+        region: {
+          data: {
+            type: "regions",
+            id: "1"
+          },
+          links: {
+            related: "http://localhost:3000/api/v2/regions/1.json"
+          }
+        },
+        external_account: {
+          data: {
+            type: "external_accounts",
+            id: "1"
+          },
+          links: {
+            related: "http://localhost:3000/api/v2/external_accounts/1.json"
+          }
+        },
+        alerts: {
+          links: {
+            related: "http://localhost:3000/api/v2/custom_signature_results/#{id}/alerts.json"
+          }
+        }
+      }
+    end
+  end
+end

--- a/test/factories/reports.rb
+++ b/test/factories/reports.rb
@@ -36,16 +36,6 @@ FactoryGirl.define do
           }
         },
         alerts: {
-          data: [
-            {
-              type: "alerts",
-              id: "41989"
-            },
-            {
-              type: "alerts",
-              id: "41988"
-            }
-          ],
           links: {
             related: "http://localhost:3000/api/v2/reports/55/alerts.json"
           }


### PR DESCRIPTION
Removed the `run` method on custom signatures.

Custom signatures will now have definitions which hold the version and code for that custom signature. Running a custom signature will now be done through the definition, by creating a result. 

The result will processed in the background when created. Later the result can be requested to get the updated status. Alerts may be requested on the result after it is in the status `complete`.

I also moved the autoload definitions for child classes to their parent classes to prevent them from being unexpectedly loaded.