### PR TITLE
Fix PaginatedCollection#next_page error when no initial params.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@ tmp
 *.so
 *.o
 *.a
+*.swp
+*.swo
 mkmf.log
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Changed
+- Calling `next_page` on queries without parameters (e.g. `ESP::ExternalAccount.all`) no longer errors.
 
 ## 2.5.0 - 2016-07-20
 ### Added

--- a/lib/esp/resources/resource.rb
+++ b/lib/esp/resources/resource.rb
@@ -63,7 +63,7 @@ module ESP
       # Need to set from so paginated collection can use it for page calls.
       object.tap do |collection|
         collection.from = options['from']
-        collection.original_params = options['params']
+        collection.original_params = options.fetch('params', {})
       end
     end
 

--- a/test/esp/extensions/active_resource/paginated_collection_test.rb
+++ b/test/esp/extensions/active_resource/paginated_collection_test.rb
@@ -119,6 +119,13 @@ module ActiveResource
               assert_predicate req.uri.query, :blank? # It will only be called once to get the first page
             end
           end
+
+          should 'not error if no initial params were supplied' do
+            stub_request(:get, /reports.json*/).to_return(body: json_list(:report, 3, page: { number: 1, size: 2 }))
+            stub_request(:put, /reports.json*/).to_return(body: json_list(:report, 3, page: { number: 2, size: 2 }))
+            reports = ESP::Report.all
+            reports.next_page
+          end
         end
 
         context '#first_page!' do


### PR DESCRIPTION
For Issue #33
Use a `fetch` when setting the `original_params` value.
Add Vim swap files to the `.gitignore`.