### PR TITLE
Protect against nulls in `included` JSON sections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Changed
+- Silently ignore `null` entires if encountered in API responses.
 
 ## 2.5.0 - 2016-07-20
 ### Added

--- a/lib/esp/extensions/active_resource/formats/json_api_format.rb
+++ b/lib/esp/extensions/active_resource/formats/json_api_format.rb
@@ -121,7 +121,7 @@ module ActiveResource # :nodoc: all
       end
 
       def self.merge_nested_included_objects(object, data, included)
-        assocs = included.select { |i| data.include?((i.slice('type', 'id'))) }
+        assocs = included.compact.select { |i| data.include?(i.slice('type', 'id')) }
         # Remove the object from the included array to prevent an infinite loop if one of it's associations relates back to itself.
         assoc_included = included.dup
         assoc_included.delete(object)

--- a/test/esp/extensions/active_resource/formats/json_api_format_test.rb
+++ b/test/esp/extensions/active_resource/formats/json_api_format_test.rb
@@ -49,6 +49,14 @@ module ActiveResource
               # nested objects too
               assert_equal parsed_json['included'].detect { |e| e['type'] == 'external_accounts' }['relationships']['organization']['data']['id'], alert.external_account.organization_id
             end
+
+            should 'not error with included nulls' do
+              manufactured_hash = JSON.parse(json_list(:alert, 1))
+              manufactured_hash['included'] << nil
+              stub_request(:put, %r{reports/1/alerts.json*}).to_return(body: manufactured_hash.to_json)
+
+              ESP::Alert.where(report_id: 1).first
+            end
           end
         end
       end


### PR DESCRIPTION
For Issue #34