### PR TITLE
Fix next_page on Dashboard.recent and Stat.latest_for_teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 ## Unreleased
 
+### Fixed
+- Fix merge error when calling next_page on Stat.latest_for_teams
+- Fix incorrect page parameter on next_page for other endpoints
+
 ## 2.6.0 - 2016-10-17
-### Changed
+### Added
 - Only send changed attributes to API #39
-- API now returns nested included relation data elements correctly.  Change test to reflect corrected response. #40
+
+### Changed
+- Switch from RDoc to Yard. #37
+
+### Fixed
+- API now returns nested included relation data elements correctly. #40
 - Calling `next_page` on queries without parameters (e.g. `ESP::ExternalAccount.all`) no longer errors. #35
 - Silently ignore `null` entires if encountered in API responses. #36
-- Switch from RDoc to Yard. #37
 
 ## 2.5.0 - 2016-07-20
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esp_sdk (2.6.0)
+    esp_sdk (2.6.1)
       activeresource (~> 4.0.0)
       api-auth (~> 2.0.0)
       rack

--- a/lib/esp/resources/dashboard.rb
+++ b/lib/esp/resources/dashboard.rb
@@ -14,8 +14,19 @@ module ESP
     # Regular ARELlike methods are disabled.
     #
     # @return [void]
-    def self.where(*)
-      fail ESP::NotImplementedError, 'Regular ARELlike methods are disabled.  Use the .recent method.'
+    def self.where(attrs)
+      # when calling `recent.next_page` it will come into here
+      if attrs[:from].to_s.include?('recent')
+        super
+      else
+        fail ESP::NotImplementedError, 'Regular ARELlike methods are disabled.  Use the .recent method.'
+      end
+    end
+
+    def self.find_every(options)
+      super.tap do |object|
+        make_pageable object, options
+      end
     end
 
     # Not Implemented. You cannot create or update a Dashboard.
@@ -38,7 +49,7 @@ module ESP
     # @return [ESP::Dashboard]
     def self.recent
       # call find_every directly since find is overridden/not implemented
-      find_every from: "#{prefix}dashboard/recent.#{format.extension}"
+      find_every from: "#{prefix}dashboard/recent"
     end
   end
 end

--- a/lib/esp/resources/dashboard.rb
+++ b/lib/esp/resources/dashboard.rb
@@ -23,12 +23,6 @@ module ESP
       end
     end
 
-    def self.find_every(options)
-      super.tap do |object|
-        make_pageable object, options
-      end
-    end
-
     # Not Implemented. You cannot create or update a Dashboard.
     #
     # @return [void]
@@ -49,7 +43,7 @@ module ESP
     # @return [ESP::Dashboard]
     def self.recent
       # call find_every directly since find is overridden/not implemented
-      find_every from: "#{prefix}dashboard/recent"
+      where from: "#{prefix}dashboard/recent"
     end
   end
 end

--- a/lib/esp/resources/resource.rb
+++ b/lib/esp/resources/resource.rb
@@ -25,7 +25,7 @@ module ESP
     def self.where(clauses = {})
       fail ArgumentError, "expected a clauses Hash, got #{clauses.inspect}" unless clauses.is_a? Hash
       from = clauses.delete(:from) || "#{prefix}#{name.demodulize.pluralize.underscore}"
-      clauses = { params: clauses }
+      clauses = { params: clauses }.with_indifferent_access
       arrange_options(clauses)
       prefix_options, query_options = split_options(clauses)
       instantiate_collection((format.decode(connection.put("#{from}.json", clauses[:params].to_json).body) || []), query_options, prefix_options).tap do |collection|

--- a/lib/esp/resources/stat.rb
+++ b/lib/esp/resources/stat.rb
@@ -46,12 +46,6 @@ module ESP
       fail ESP::NotImplementedError, 'Regular ARELlike methods are disabled.  Use either the ESP::Stat.for_report or ESP::Stat.latest_for_teams method.'
     end
 
-    def self.find_every(options)
-      super.tap do |object|
-        make_pageable object, options
-      end
-    end
-
     # @!method self.create
     #   Not Implemented. You cannot create a Stat.
     #
@@ -93,7 +87,7 @@ module ESP
     # @return [ActiveResource::PaginatedCollection<ESP::Stat>]
     def self.latest_for_teams
       # call find_every directly since find is overriden/not implemented
-      find_every(from: "#{prefix}stats/latest_for_teams")
+      where(from: "#{prefix}stats/latest_for_teams")
     end
 
     # @!group 'total' rollup methods

--- a/lib/esp/resources/stat.rb
+++ b/lib/esp/resources/stat.rb
@@ -30,8 +30,13 @@ module ESP
     # Not Implemented. You cannot search for a Stat.
     #
     # @return [void]
-    def self.where(*)
-      fail ESP::NotImplementedError
+    def self.where(attrs)
+      # when calling `latest_for_teams.next_page` it will come into here
+      if attrs[:from].to_s.include?('latest_for_teams')
+        super
+      else
+        fail ESP::NotImplementedError
+      end
     end
 
     # Not Implemented. You cannot search for a Stat.
@@ -39,6 +44,12 @@ module ESP
     # @return [void]
     def self.find(*)
       fail ESP::NotImplementedError, 'Regular ARELlike methods are disabled.  Use either the ESP::Stat.for_report or ESP::Stat.latest_for_teams method.'
+    end
+
+    def self.find_every(options)
+      super.tap do |object|
+        make_pageable object, options
+      end
     end
 
     # @!method self.create
@@ -82,7 +93,7 @@ module ESP
     # @return [ActiveResource::PaginatedCollection<ESP::Stat>]
     def self.latest_for_teams
       # call find_every directly since find is overriden/not implemented
-      find_every(from: :latest_for_teams)
+      find_every(from: "#{prefix}stats/latest_for_teams")
     end
 
     # @!group 'total' rollup methods

--- a/lib/esp/version.rb
+++ b/lib/esp/version.rb
@@ -1,3 +1,3 @@
 module ESP
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.1'.freeze
 end

--- a/test/esp/extensions/active_resource/formats/json_api_format_test.rb
+++ b/test/esp/extensions/active_resource/formats/json_api_format_test.rb
@@ -9,7 +9,7 @@ module ActiveResource
             should 'parse nested objects correctly' do
               json        = json(:dashboard)
               parsed_json = JSON.parse(json)
-              stub_request(:get, %r{dashboard/recent.json*}).to_return(body: json_list(:dashboard, 1))
+              stub_request(:get, %r{dashboard/recent*}).to_return(body: json_list(:dashboard, 1))
 
               dashboard = ESP::Dashboard.recent
 

--- a/test/esp/extensions/active_resource/formats/json_api_format_test.rb
+++ b/test/esp/extensions/active_resource/formats/json_api_format_test.rb
@@ -9,7 +9,7 @@ module ActiveResource
             should 'parse nested objects correctly' do
               json        = json(:dashboard)
               parsed_json = JSON.parse(json)
-              stub_request(:get, %r{dashboard/recent*}).to_return(body: json_list(:dashboard, 1))
+              stub_request(:put, %r{dashboard/recent*}).to_return(body: json_list(:dashboard, 1))
 
               dashboard = ESP::Dashboard.recent
 

--- a/test/esp/resources/dashboard_test.rb
+++ b/test/esp/resources/dashboard_test.rb
@@ -47,7 +47,7 @@ module ESP
 
       context '.recent' do
         should 'call the api and return an array of dashboard objects' do
-          stubbed_dashboard = stub_request(:get, %r{dashboard/recent*}).to_return(body: json_list(:dashboard, 2))
+          stubbed_dashboard = stub_request(:put, %r{dashboard/recent*}).to_return(body: json_list(:dashboard, 2))
 
           dashboard = ESP::Dashboard.recent
 
@@ -57,7 +57,7 @@ module ESP
 
         context 'next_page' do
           should 'request page 2 when multiple dashboards' do
-            stub_dashboard = stub_request(:get, %r{dashboard/recent*}).with(body: nil).to_return(body: json_list(:dashboard, 25))
+            stub_dashboard = stub_request(:put, %r{dashboard/recent*}).with(body: {}.to_json).to_return(body: json_list(:dashboard, 25))
             stub_dashboard2 = stub_request(:put, %r{dashboard/recent*}).with(body: { filter: {}, page: { number: '2', size: '20' } }.to_json).to_return(body: json_list(:stat, 2))
 
             dashboard = ESP::Dashboard.recent

--- a/test/esp/resources/dashboard_test.rb
+++ b/test/esp/resources/dashboard_test.rb
@@ -47,12 +47,25 @@ module ESP
 
       context '.recent' do
         should 'call the api and return an array of dashboard objects' do
-          stubbed_dashboard = stub_request(:get, %r{dashboard/recent.json*}).to_return(body: json_list(:dashboard, 2))
+          stubbed_dashboard = stub_request(:get, %r{dashboard/recent*}).to_return(body: json_list(:dashboard, 2))
 
           dashboard = ESP::Dashboard.recent
 
           assert_requested(stubbed_dashboard)
           assert_equal ESP::Dashboard, dashboard.resource_class
+        end
+
+        context 'next_page' do
+          should 'request page 2 when multiple dashboards' do
+            stub_dashboard = stub_request(:get, %r{dashboard/recent*}).with(body: nil).to_return(body: json_list(:dashboard, 25))
+            stub_dashboard2 = stub_request(:put, %r{dashboard/recent*}).with(body: { filter: {}, page: { number: '2', size: '20' } }.to_json).to_return(body: json_list(:stat, 2))
+
+            dashboard = ESP::Dashboard.recent
+            dashboard.next_page
+
+            assert_requested(stub_dashboard)
+            assert_requested(stub_dashboard2)
+          end
         end
       end
     end

--- a/test/esp/resources/resource_test.rb
+++ b/test/esp/resources/resource_test.rb
@@ -149,6 +149,17 @@ module ESP
 
             assert_equal '/api/v2/teams.json', teams.from
           end
+
+          should 'request next_page with page parameters' do
+            get_request = stub_request(:get, /teams.json*/).to_return(body: json_list(:team, 25))
+            next_page_request = stub_request(:put, /teams.json*/).with(body: { filter: {}, page: { number: '2', size: '20' } }.to_json).to_return(body: json_list(:team, 25))
+
+            teams = ESP::Team.all
+            teams.next_page
+
+            assert_requested(get_request)
+            assert_requested(next_page_request)
+          end
         end
 
         context '.where' do

--- a/test/esp/resources/stat_test.rb
+++ b/test/esp/resources/stat_test.rb
@@ -122,12 +122,25 @@ module ESP
 
       context '.latest_for_teams' do
         should 'call the api and return a collection of stats' do
-          stub_stat = stub_request(:get, %r{stats/latest_for_teams.json*}).to_return(body: json_list(:stat, 2))
+          stub_stat = stub_request(:get, %r{stats/latest_for_teams*}).to_return(body: json_list(:stat, 2))
 
           stats = ESP::Stat.latest_for_teams
 
           assert_requested(stub_stat)
           assert_equal ESP::Stat, stats.resource_class
+        end
+
+        context 'next_page' do
+          should 'request page 2 when multiple stats' do
+            stub_stat = stub_request(:get, %r{stats/latest_for_teams*}).with(body: nil).to_return(body: json_list(:stat, 25))
+            stub_stat2 = stub_request(:put, %r{stats/latest_for_teams*}).with(body: { filter: {}, page: { number: '2', size: '20' } }.to_json).to_return(body: json_list(:stat, 2))
+
+            stats = ESP::Stat.latest_for_teams
+            stats.next_page
+
+            assert_requested(stub_stat)
+            assert_requested(stub_stat2)
+          end
         end
       end
     end

--- a/test/esp/resources/stat_test.rb
+++ b/test/esp/resources/stat_test.rb
@@ -122,7 +122,7 @@ module ESP
 
       context '.latest_for_teams' do
         should 'call the api and return a collection of stats' do
-          stub_stat = stub_request(:get, %r{stats/latest_for_teams*}).to_return(body: json_list(:stat, 2))
+          stub_stat = stub_request(:put, %r{stats/latest_for_teams*}).to_return(body: json_list(:stat, 2))
 
           stats = ESP::Stat.latest_for_teams
 
@@ -132,7 +132,7 @@ module ESP
 
         context 'next_page' do
           should 'request page 2 when multiple stats' do
-            stub_stat = stub_request(:get, %r{stats/latest_for_teams*}).with(body: nil).to_return(body: json_list(:stat, 25))
+            stub_stat = stub_request(:put, %r{stats/latest_for_teams*}).with(body: {}.to_json).to_return(body: json_list(:stat, 25))
             stub_stat2 = stub_request(:put, %r{stats/latest_for_teams*}).with(body: { filter: {}, page: { number: '2', size: '20' } }.to_json).to_return(body: json_list(:stat, 2))
 
             stats = ESP::Stat.latest_for_teams


### PR DESCRIPTION
Calling `next_page` on `Dashboard.recent` or `Stat.latest_for_teams` would return a merge for nil error. This turned out to be because the pagination wasn't set up when calling `find_every`. After fixing that it was discovered that the `PaginatedCollection` uses `where` for `next_page` calls so that had to be enabled.

This also requires some server side changes due to `where` making a PUT request. PUT was not supported for these two endpoints previously.

I also discovered that `next_page` would cause a server side error on other APIs. This was because the logic in `where` that parses the page numbers was not always a symbol key, causing the page parameter to get merged into the filter params. I fixed this by adding a `with_indifferent_access` on the params before they are parsed.

This fixes the reopening of #33.