### PR TITLE
Adding heredoc regex to remove leading whitespace from JSON literal

### DIFF
--- a/lib/esp/aws_clients.rb
+++ b/lib/esp/aws_clients.rb
@@ -36,7 +36,7 @@ module ESP
     end
 
     def trust_policy(external_account_id) # rubocop:disable Metrics/MethodLength
-      <<TRUST_POLICY
+      <<-TRUST_POLICY.gsub /^\s*/, ''
   {
     "Version": "2012-10-17",
     "Statement": [

--- a/lib/esp/aws_clients.rb
+++ b/lib/esp/aws_clients.rb
@@ -36,7 +36,7 @@ module ESP
     end
 
     def trust_policy(external_account_id) # rubocop:disable Metrics/MethodLength
-      <<-TRUST_POLICY.gsub /^\s*/, ''
+      <<-TRUST_POLICY.gsub(/^\s*/, '')
   {
     "Version": "2012-10-17",
     "Statement": [


### PR DESCRIPTION
Since the Json had leading whitespace it was resulting in a MalformedPolicyDocument when atempting to create the IAM role. This fix removes leading whitespace and retains the formatting.